### PR TITLE
Feature/#28 refactor to es6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+dist/
 npm-debug.log
 *.code-workspace
 .env

--- a/__tests__/fake.test.js
+++ b/__tests__/fake.test.js
@@ -1,5 +1,5 @@
 // A fake test to get the build to pass before I get started on adding tests
 
 test('Always passes', () => {
-  expect(true).toBe(true);
+  expect(true).toBe(true)
 })

--- a/config/config.js
+++ b/config/config.js
@@ -1,15 +1,19 @@
-module.exports = {
-    //MongoDB configuration
-    development: {
-        db: process.env.MONGO_URI_DEV,
-        app: {
-            name: 'graphql'
-        }
-    },
-    production: {
-        db: process.env.MONGO_URI_PROD,
-        app: {
-            name: 'graphql'
-        }
+// Import env file
+import dotenv from 'dotenv'
+dotenv.config()
+
+export default {
+  // MongoDB configuration
+  development: {
+    db: process.env.MONGO_URI_DEV,
+    app: {
+      name: 'graphql'
     }
-};
+  },
+  production: {
+    db: process.env.MONGO_URI_PROD,
+    app: {
+      name: 'graphql'
+    }
+  }
+}

--- a/config/mongoose.js
+++ b/config/mongoose.js
@@ -1,14 +1,15 @@
-var env = process.env.NODE_ENV || 'development',
-    config = require('./config')[env],
-    mongoose = require('mongoose');
+import config from './config'
+import mongoose from 'mongoose'
 
-module.exports = function () {
-    mongoose.Promise = global.Promise;
-    var db = mongoose.connect(config.db);
-    mongoose.connection.on('error', function (err) {
-        console.log('Error: Could not connect to MongoDB. Did you forget to run `mongod`?'.red);
-    }).on('open', function () {
-        console.log('Connection extablised with MongoDB')
-    })
-    return db;
-};
+const env = process.env.NODE_ENV || 'development'
+
+export default function () {
+  mongoose.Promise = global.Promise
+  const db = mongoose.connect(config[env].db)
+  mongoose.connection.on('error', function (err) {
+    console.log('Error: Could not connect to MongoDB. Did you forget to run `mongod`?'.red)
+  }).on('open', function () {
+    console.log('Connection extablised with MongoDB')
+  })
+  return db
+}

--- a/graphql/index.js
+++ b/graphql/index.js
@@ -1,8 +1,8 @@
-var GraphQLSchema = require('graphql').GraphQLSchema;
-var RootQuery = require('./queries').queryType;
-var RootMutation = require('./mutations').mutationType;
+import { GraphQLSchema } from 'graphql'
+import RootQuery from './queries'
+import RootMutation from './mutations'
 
-exports.appSchema = new GraphQLSchema({
+export default new GraphQLSchema({
   query: RootQuery,
   mutation: RootMutation
 })

--- a/graphql/mutations/brands/add.js
+++ b/graphql/mutations/brands/add.js
@@ -1,12 +1,12 @@
-var GraphQLNonNull = require('graphql').GraphQLNonNull
-var BrandsType = require('../../types/brands')
-var BrandsModel = require('../../../models/brands')
+import { GraphQLNonNull } from 'graphql'
+import { brandsType, brandsInputType } from '../../types/brands'
+import BrandsModel from '../../../models/brands'
 
-exports.add = {
-  type: BrandsType.brandsType,
+export default {
+  type: brandsType,
   args: {
     brandsAdd: {
-      type: BrandsType.brandsInputType
+      type: brandsInputType
     }
   },
   resolve(root, { brandsAdd }) {

--- a/graphql/mutations/brands/index.js
+++ b/graphql/mutations/brands/index.js
@@ -1,11 +1,9 @@
-var GraphQLObjectType = require('graphql').GraphQLObjectType;
+// TODO: This page and others like it are kind of a waste of time. Refactor
 
-var add = require('./add').add;
-var remove = require('./remove').remove;
-var update = require('./update').update;
+import { GraphQLObjectType } from 'graphql'
 
-module.exports = {
- add,
- remove,
- update 
-}
+import add from './add'
+import remove from './remove'
+import update from './update'
+
+export default { add, remove, update}

--- a/graphql/mutations/brands/remove.js
+++ b/graphql/mutations/brands/remove.js
@@ -1,10 +1,9 @@
-var GraphQLNonNull = require('graphql').GraphQLNonNull
-var GraphQLString = require('graphql').GraphQLString
-var BrandsType = require('../../types/brands')
-var BrandsModel = require('../../../models/brands')
+import { GraphQLNonNull, GraphQLString } from 'graphql'
+import { brandsType } from '../../types/brands'
+import BrandsModel from '../../../models/brands'
 
-exports.remove = {
-  type: BrandsType.brandsType,
+export default {
+  type: brandsType,
   args: {
     id: {
       type: new GraphQLNonNull(GraphQLString)

--- a/graphql/mutations/brands/update.js
+++ b/graphql/mutations/brands/update.js
@@ -1,29 +1,28 @@
-var GraphQLNonNull = require('graphql').GraphQLNonNull
-var GraphQLString = require('graphql').GraphQLString
-var BrandsType = require('../../types/brands')
-var BrandsModel = require('../../../models/brands')
+import { GraphQLNonNull, GraphQLString } from 'graphql'
+import { brandsType, brandsInputType } from '../../types/brands'
+import BrandsModel from '../../../models/brands'
 
-exports.update = {
-  type: BrandsType.brandsType,
+export default {
+  type: brandsType,
   description: 'Update a brand',
   args: {
     id: {
       name: 'id',
       type: new GraphQLNonNull(GraphQLString)
     },
-    brandsUpdate: { type: BrandsType.brandsInputType }
+    brandsUpdate: { type: brandsInputType }
   },
   resolve(root, { id, brandsUpdate }) {
     return BrandsModel.findByIdAndUpdate(
       id,
       {
-        name: brandsType.name,
-        description: brandsType.description,
-        logo_url: brandsType.logo_url,
-        bg_url: brandsType.bg_url,
-        cta_url: brandsType.cta_url,
-        class: brandsType.class,
-        active: brandsType.active
+        name: brandsUpdate.name,
+        description: brandsUpdate.description,
+        logo_url: brandsUpdate.logo_url,
+        bg_url: brandsUpdate.bg_url,
+        cta_url: brandsUpdate.cta_url,
+        class: brandsUpdate.class,
+        active: brandsUpdate.active
       },
       { new: true }
     ).exec()

--- a/graphql/mutations/config/index.js
+++ b/graphql/mutations/config/index.js
@@ -1,13 +1,12 @@
-var GraphQLNonNull = require('graphql').GraphQLNonNull
-var GraphQLString = require('graphql').GraphQLString
-var ConfigType = require('../../types/config')
-var ConfigModel = require('../../../models/config')
+import { GraphQLNonNull, GraphQLString } from 'graphql'
+import { configType, configInputType } from '../../types/config'
+import ConfigModel from '../../../models/config'
 
-exports.update = {
-  type: ConfigType.configType,
+export default {
+  type: configType,
   description: 'Update a config item',
   args: {
-    configUpdate: { type: ConfigType.configInputType }
+    configUpdate: { type: configInputType }
   },
   resolve(root, { configUpdate }) {
     return ConfigModel.findOneAndUpdate(

--- a/graphql/mutations/contact-details/add.js
+++ b/graphql/mutations/contact-details/add.js
@@ -1,8 +1,8 @@
-var GraphQLNonNull = require('graphql').GraphQLNonNull
-var ContactDetailsType = require('../../types/contact-details')
-var ContactDetailsModel = require('../../../models/contact-details')
+import { GraphQLNonNull } from 'graphql'
+import ContactDetailsType from '../../types/contact-details'
+import ContactDetailsModel from '../../../models/contact-details'
 
-exports.add = {
+export default add = {
   type: ContactDetailsType.contactDetailsType,
   args: {
     contactDetailsAdd: {

--- a/graphql/mutations/contact-details/index.js
+++ b/graphql/mutations/contact-details/index.js
@@ -1,11 +1,7 @@
-var GraphQLObjectType = require('graphql').GraphQLObjectType;
+import { GraphQLObjectType } from 'graphql'
 
-var add = require('./add').add;
-var remove = require('./remove').remove;
-var update = require('./update').update;
+import add from './add'
+import remove from './remove'
+import update from './update'
 
-module.exports = {
- add,
- remove,
- update 
-}
+export default { add, remove, update }

--- a/graphql/mutations/contact-details/remove.js
+++ b/graphql/mutations/contact-details/remove.js
@@ -1,9 +1,8 @@
-var GraphQLNonNull = require('graphql').GraphQLNonNull
-var GraphQLString = require('graphql').GraphQLString
-var ContactDetailsType = require('../../types/contact-details')
-var ContactDetailsModel = require('../../../models/contact-details')
+import { GraphQLNonNull, GraphQLString } from 'graphql'
+import ContactDetailsType from '../../types/contact-details'
+import ContactDetailsModel from '../../../models/contact-details'
 
-exports.remove = {
+export default remove = {
   type: ContactDetailsType.contactDetailsType,
   args: {
     id: {

--- a/graphql/mutations/contact-details/update.js
+++ b/graphql/mutations/contact-details/update.js
@@ -1,9 +1,8 @@
-var GraphQLNonNull = require('graphql').GraphQLNonNull
-var GraphQLString = require('graphql').GraphQLString
-var ContactDetailsType = require('../../types/contact-details')
-var ContactDetailsModel = require('../../../models/contact-details')
+import { GraphQLNonNull, GraphQLString } from 'graphql'
+import ContactDetailsType from '../../types/contact-details'
+import ContactDetailsModel from '../../../models/contact-details'
 
-exports.update = {
+export default update = {
   type: ContactDetailsType.contactDetailsType,
   description: 'Update a contact method',
   args: {

--- a/graphql/mutations/index.js
+++ b/graphql/mutations/index.js
@@ -1,18 +1,18 @@
-var GraphQLObjectType = require('graphql').GraphQLObjectType
+import { GraphQLObjectType } from 'graphql'
 
-var config = require('./config')
-var lang = require('./lang')
-var skills = require('./skills')
-var brands = require('./brands')
-var socialNetworks = require('./social-networks')
+import updateConfig from './config'
+import updateLang from './lang'
+import skills from './skills'
+import brands from './brands'
+import socialNetworks from './social-networks'
 
-exports.mutationType = new GraphQLObjectType({
+export default new GraphQLObjectType({
   name: 'Mutation',
   description: 'Root mutation',
-  fields: function () {
+  fields: () => {
     return {
-      updateConfig: config.update,
-      updateLang: lang.update,
+      updateConfig,
+      updateLang,
       addSkill: skills.add,
       updateSkill: skills.update,
       removeSkill: skills.remove,
@@ -21,7 +21,7 @@ exports.mutationType = new GraphQLObjectType({
       removeBrand: brands.remove,
       addSocialNetwork: socialNetworks.add,
       updateSocialNetwork: socialNetworks.update,
-      removeSocialNetwork: socialNetworks.remove,
+      removeSocialNetwork: socialNetworks.remove
     }
   }
 })

--- a/graphql/mutations/lang/index.js
+++ b/graphql/mutations/lang/index.js
@@ -1,13 +1,12 @@
-var GraphQLNonNull = require('graphql').GraphQLNonNull
-var GraphQLString = require('graphql').GraphQLString
-var LangType = require('../../types/lang')
-var LangModel = require('../../../models/lang')
+import { GraphQLNonNull, GraphQLString } from 'graphql'
+import { langType, langInputType } from '../../types/lang'
+import LangModel from '../../../models/lang'
 
-exports.update = {
-  type: LangType.langType,
+export default {
+  type: langType,
   description: 'Update a language item',
   args: {
-    langUpdate: { type: LangType.langInputType }
+    langUpdate: { type: langInputType }
   },
   resolve(root, { langUpdate }) {
     return LangModel.findOneAndUpdate(

--- a/graphql/mutations/skills/add.js
+++ b/graphql/mutations/skills/add.js
@@ -1,12 +1,12 @@
-var GraphQLNonNull = require('graphql').GraphQLNonNull
-var SkillsType = require('../../types/skills')
-var SkillsModel = require('../../../models/skills')
+import { GraphQLNonNull } from 'graphql'
+import { skillsType, skillsInputType } from '../../types/skills'
+import SkillsModel from '../../../models/skills'
 
-exports.add = {
-  type: SkillsType.skillsType,
+export default {
+  type: skillsType,
   args: {
     skillsAdd: {
-      type: SkillsType.skillsInputType
+      type: skillsInputType
     }
   },
   resolve(root, { skillsAdd }) {

--- a/graphql/mutations/skills/index.js
+++ b/graphql/mutations/skills/index.js
@@ -1,11 +1,7 @@
-var GraphQLObjectType = require('graphql').GraphQLObjectType;
+import { GraphQLObjectType } from 'graphql'
 
-var add = require('./add').add;
-var remove = require('./remove').remove;
-var update = require('./update').update;
+import add from './add'
+import remove from './remove'
+import update from './update'
 
-module.exports = {
- add,
- remove,
- update 
-}
+export default { add, remove, update}

--- a/graphql/mutations/skills/remove.js
+++ b/graphql/mutations/skills/remove.js
@@ -1,10 +1,9 @@
-var GraphQLNonNull = require('graphql').GraphQLNonNull
-var GraphQLString = require('graphql').GraphQLString
-var SkillsType = require('../../types/skills')
-var SkillsModel = require('../../../models/skills')
+import { GraphQLNonNull, GraphQLString } from 'graphql'
+import { skillsType } from '../../types/skills'
+import SkillsModel from '../../../models/skills'
 
-exports.remove = {
-  type: SkillsType.skillsType,
+export default {
+  type: skillsType,
   args: {
     id: {
       type: new GraphQLNonNull(GraphQLString)

--- a/graphql/mutations/skills/update.js
+++ b/graphql/mutations/skills/update.js
@@ -1,17 +1,16 @@
-var GraphQLNonNull = require('graphql').GraphQLNonNull
-var GraphQLString = require('graphql').GraphQLString
-var SkillsType = require('../../types/skills')
-var SkillsModel = require('../../../models/skills')
+import { GraphQLNonNull, GraphQLString } from 'graphql'
+import { skillsType, skillsInputType } from '../../types/skills'
+import SkillsModel from '../../../models/skills'
 
-exports.update = {
-  type: SkillsType.skillsType,
+export default {
+  type: skillsType,
   description: 'Update a skill',
   args: {
     id: {
       name: 'id',
       type: new GraphQLNonNull(GraphQLString)
     },
-    skillsUpdate: { type: SkillsType.skillsInputType }
+    skillsUpdate: { type: skillsInputType }
   },
   resolve(root, { id, skillsUpdate }) {
     return SkillsModel.findByIdAndUpdate(

--- a/graphql/mutations/social-networks/add.js
+++ b/graphql/mutations/social-networks/add.js
@@ -1,12 +1,12 @@
-var GraphQLNonNull = require('graphql').GraphQLNonNull
-var SocialNetworksType = require('../../types/social-networks')
-var SocialNetworksModel = require('../../../models/social-networks')
+import { GraphQLNonNull } from 'graphql'
+import { socialNetworksType, socialNetworksInputType } from '../../types/social-networks'
+import SocialNetworksModel from '../../../models/social-networks'
 
-exports.add = {
-  type: SocialNetworksType.socialNetworksType,
+export default {
+  type: socialNetworksType,
   args: {
     socialNetworksAdd: {
-      type: SocialNetworksType.socialNetworksInputType
+      type: socialNetworksInputType
     }
   },
   resolve(root, { socialNetworksAdd }) {

--- a/graphql/mutations/social-networks/index.js
+++ b/graphql/mutations/social-networks/index.js
@@ -1,11 +1,7 @@
-var GraphQLObjectType = require('graphql').GraphQLObjectType;
+import { GraphQLObjectType } from 'graphql'
 
-var add = require('./add').add;
-var remove = require('./remove').remove;
-var update = require('./update').update;
+import add from './add'
+import remove from './remove'
+import update from './update'
 
-module.exports = {
- add,
- remove,
- update 
-}
+export default { add, remove, update}

--- a/graphql/mutations/social-networks/remove.js
+++ b/graphql/mutations/social-networks/remove.js
@@ -1,10 +1,9 @@
-var GraphQLNonNull = require('graphql').GraphQLNonNull
-var GraphQLString = require('graphql').GraphQLString
-var SocialNetworksType = require('../../types/social-networks')
-var SocialNetworksModel = require('../../../models/social-networks')
+import { GraphQLNonNull, GraphQLString } from 'graphql'
+import { socialNetworksType } from '../../types/social-networks'
+import SocialNetworksModel from '../../../models/social-networks'
 
-exports.remove = {
-  type: SocialNetworksType.socialNetworksType,
+export default {
+  type: socialNetworksType,
   args: {
     id: {
       type: new GraphQLNonNull(GraphQLString)

--- a/graphql/mutations/social-networks/update.js
+++ b/graphql/mutations/social-networks/update.js
@@ -1,28 +1,27 @@
-var GraphQLNonNull = require('graphql').GraphQLNonNull
-var GraphQLString = require('graphql').GraphQLString
-var SocialNetworksType = require('../../types/social-networks')
-var SocialNetworksModel = require('../../../models/social-networks')
+import { GraphQLNonNull, GraphQLString } from 'graphql'
+import { socialNetworksType, socialNetworksInputType } from '../../types/social-networks'
+import SocialNetworksModel from '../../../models/social-networks'
 
-exports.update = {
-  type: SocialNetworksType.socialNetworksType,
+export default {
+  type: socialNetworksType,
   description: 'Update a social network',
   args: {
     id: {
       name: 'id',
       type: new GraphQLNonNull(GraphQLString)
     },
-    socialNetworksUpdate: { type: SocialNetworksType.socialNetworksInputType }
+    socialNetworksUpdate: { type: socialNetworksInputType }
   },
   resolve(root, { id, socialNetworksUpdate }) {
     return SocialNetworksModel.findByIdAndUpdate(
       id,
       {
-        name: socialNetworksType.name,
-        icon_class: socialNetworksType.icon_class,
-        username: socialNetworksType.username,
-        profile_url: socialNetworksType.profile_url,
-        cta: socialNetworksType.cta,
-        active: socialNetworksType.active
+        name: socialNetworksUpdate.name,
+        icon_class: socialNetworksUpdate.icon_class,
+        username: socialNetworksUpdate.username,
+        profile_url: socialNetworksUpdate.profile_url,
+        cta: socialNetworksUpdate.cta,
+        active: socialNetworksUpdate.active
       },
       { new: true }
     ).exec()

--- a/graphql/queries/brands.js
+++ b/graphql/queries/brands.js
@@ -1,12 +1,12 @@
-var GraphQLList = require('graphql').GraphQLList
-var BrandsModel = require('../../models/brands')
-var BrandsType = require('../types/brands').brandsType
+import { GraphQLList } from 'graphql'
+import BrandsModel from '../../models/brands'
+import { brandsType as BrandsType } from '../types/brands'
 
 // Query
-exports.queryType = {
+export default {
   type: new GraphQLList(BrandsType),
   description: 'The brands I have worked for',
-  resolve: function () {
+  resolve: () => {
     const brands = BrandsModel.find()
     if (!brands) {
       throw new Error('Error')

--- a/graphql/queries/config.js
+++ b/graphql/queries/config.js
@@ -1,11 +1,11 @@
-var GraphQLList = require('graphql').GraphQLList;
-var ConfigModel = require('../../models/config');
-var ConfigType = require('../types/config').configType;
+import { GraphQLList } from 'graphql'
+import ConfigModel from '../../models/config'
+import { configType as ConfigType } from '../types/config'
 
 // Query
-exports.queryType = {
+export default {
   type: new GraphQLList(ConfigType),
-  description: 'The configuration for the home \'page\'',
+  description: "The configuration for the home 'page'",
   resolve: function () {
     const config = ConfigModel.find()
     if (!config) {

--- a/graphql/queries/contact-details.js
+++ b/graphql/queries/contact-details.js
@@ -1,12 +1,12 @@
-var GraphQLList = require('graphql').GraphQLList;
-var ContactDetailsModel = require('../../models/contact-details');
-var ContactDetailsType = require('../types/contact-details').contactDetailsType;
+import { GraphQLList } from 'graphql'
+import ContactDetailsModel from '../../models/contact-details'
+import { contactDetailsType as ContactDetailsType } from '../types/contact-details'
 
 // Query
-exports.queryType = {
+export default {
   type: new GraphQLList(ContactDetailsType),
   description: 'The contact details to display on the site.',
-  resolve: function () {
+  resolve: () => {
     const contact_details = ContactDetailsModel.find()
     if (!contact_details) {
       throw new Error('Error')

--- a/graphql/queries/index.js
+++ b/graphql/queries/index.js
@@ -1,26 +1,25 @@
-var GraphQLObjectType = require('graphql').GraphQLObjectType
-var GraphQLList = require('graphql').GraphQLList
+import { GraphQLObjectType, GraphQLList } from 'graphql'
 
 // Import queries
-var configQuery = require('./config').queryType
-var contactDetailsQuery = require('./contact-details').queryType
-var socialNetworksQuery = require('./social-networks').queryType
-var skillsQuery = require('./skills').queryType
-var brandsQuery = require('./brands').queryType
-var langQuery = require('./lang').queryType
+import configQuery from './config'
+import contactDetailsQuery from './contact-details'
+import socialNetworksQuery from './social-networks'
+import skillsQuery from './skills'
+import brandsQuery from './brands'
+import langQuery from './lang'
 
 // Query
-exports.queryType = new GraphQLObjectType({
+export default new GraphQLObjectType({
   name: 'Query',
   description: 'Root Query',
-  fields: function () {
+  fields: () => {
     return {
       config: configQuery,
       contact_details: contactDetailsQuery,
       social_networks: socialNetworksQuery,
       skills: skillsQuery,
       brands: brandsQuery,
-      lang: langQuery,
+      lang: langQuery
     }
   }
 })

--- a/graphql/queries/lang.js
+++ b/graphql/queries/lang.js
@@ -1,12 +1,13 @@
-var GraphQLList = require('graphql').GraphQLList;
-var LangModel = require('../../models/lang');
-var LangType = require('../types/lang').langType;
+import { GraphQLList } from 'graphql'
+import LangModel from '../../models/lang'
+import { langType as LangType } from '../types/lang'
+import { __importDefault } from 'tslib'
 
 // Query
-exports.queryType = {
+export default {
   type: new GraphQLList(LangType),
   description: 'Various text snippets used throughout the site',
-  resolve: function () {
+  resolve: () => {
     const lang = LangModel.find()
     if (!lang) {
       throw new Error('Error')

--- a/graphql/queries/skills.js
+++ b/graphql/queries/skills.js
@@ -1,12 +1,12 @@
-var GraphQLList = require('graphql').GraphQLList;
-var SkillsModel = require('../../models/skills');
-var SkillsType = require('../types/skills').skillsType;
+import { GraphQLList } from 'graphql'
+import SkillsModel from '../../models/skills'
+import { skillsType as SkillsType } from '../types/skills'
 
 // Query
-exports.queryType = {
+export default {
   type: new GraphQLList(SkillsType),
   description: 'The skills I possess',
-  resolve: function () {
+  resolve: () => {
     const skills = SkillsModel.find()
     if (!skills) {
       throw new Error('Error')

--- a/graphql/queries/social-networks.js
+++ b/graphql/queries/social-networks.js
@@ -1,12 +1,12 @@
-var GraphQLList = require('graphql').GraphQLList;
-var SocialNetworksModel = require('../../models/social-networks');
-var SocialNetworksType = require('../types/social-networks').socialNetworksType;
+import { GraphQLList } from 'graphql'
+import SocialNetworksModel from '../../models/social-networks'
+import { socialNetworksType as SocialNetworksType } from '../types/social-networks'
 
 // Query
-exports.queryType = {
+export default {
   type: new GraphQLList(SocialNetworksType),
   description: 'A list of social networks.  (Note: This is also used to connect to a few adjacent APIs so do not delete any entries without checking)',
-  resolve: function () {
+  resolve: () => {
     const social_networks = SocialNetworksModel.find()
     if (!social_networks) {
       throw new Error('Error')

--- a/graphql/types/brands.js
+++ b/graphql/types/brands.js
@@ -1,13 +1,6 @@
-var GraphQLObjectType = require('graphql').GraphQLObjectType
-var GraphQLInputObjectType = require('graphql').GraphQLInputObjectType
-var GraphQLNonNull = require('graphql').GraphQLNonNull
-var GraphQLBoolean = require('graphql').GraphQLBoolean
-var GraphQLList = require('graphql').GraphQLList
-var GraphQLID = require('graphql').GraphQLID
-var GraphQLString = require('graphql').GraphQLString
-var GraphQLInt = require('graphql').GraphQLInt
+import { GraphQLObjectType, GraphQLInputObjectType, GraphQLNonNull, GraphQLBoolean, GraphQLList, GraphQLID, GraphQLString, GraphQLInt } from 'graphql'
 
-var dataShape = {
+const dataShape = {
   name: {
     type: GraphQLString,
     description: 'The name of the skill'
@@ -39,13 +32,15 @@ var dataShape = {
 }
 
 // Brands Type
-exports.brandsType = new GraphQLObjectType({
+const brandsType = new GraphQLObjectType({
   name: 'brands',
   fields: () => dataShape
 })
 
 // Brands Input Type
-exports.brandsInputType = new GraphQLInputObjectType({
+const brandsInputType = new GraphQLInputObjectType({
   name: 'brandsInputType',
   fields: () => dataShape
 })
+
+export { brandsType, brandsInputType }

--- a/graphql/types/component.js
+++ b/graphql/types/component.js
@@ -1,7 +1,6 @@
-var GraphQLObjectType = require('graphql').GraphQLObjectType
-var GraphQLString = require('graphql').GraphQLString
+import { GraphQLObjectType, GraphQLString } from 'graphql'
 
-var dataShape = {
+const dataShape = {
   name: {
     type: GraphQLString,
     description: 'The name of the component'
@@ -13,7 +12,7 @@ var dataShape = {
 }
 
 // Component Type
-exports.componentType = new GraphQLObjectType({
+export const componentType = new GraphQLObjectType({
   name: 'component',
   fields: () => dataShape
 })

--- a/graphql/types/config.js
+++ b/graphql/types/config.js
@@ -1,12 +1,14 @@
-var GraphQLObjectType = require('graphql').GraphQLObjectType
-var GraphQLInputObjectType = require('graphql').GraphQLInputObjectType
-var GraphQLNonNull = require('graphql').GraphQLNonNull
-var GraphQLBoolean = require('graphql').GraphQLBoolean
-var GraphQLList = require('graphql').GraphQLList
-var GraphQLID = require('graphql').GraphQLID
-var GraphQLString = require('graphql').GraphQLString
+import { 
+  GraphQLObjectType,
+  GraphQLInputObjectType,
+  GraphQLNonNull,
+  GraphQLBoolean,
+  GraphQLList,
+  GraphQLID,
+  GraphQLString } from 'graphql'
 
-var dataShape = {
+
+const dataShape = {
   status: {
     type: GraphQLString,
     description: 'My current contracting status, can be anything but is usually `available`, `unavailable` or `taking a break`'
@@ -26,13 +28,16 @@ var dataShape = {
 }
 
 // Config Type
-exports.configType = new GraphQLObjectType({
+const configType = new GraphQLObjectType({
   name: 'config',
   fields: () => dataShape
 })
 
 // Config Input Type
-exports.configInputType = new GraphQLInputObjectType({
+const configInputType = new GraphQLInputObjectType({
   name: 'configInputType',
   fields: () => dataShape
 })
+
+
+export { configType, configInputType }

--- a/graphql/types/contact-details.js
+++ b/graphql/types/contact-details.js
@@ -1,9 +1,6 @@
-var GraphQLObjectType = require('graphql').GraphQLObjectType
-var GraphQLInputObjectType = require('graphql').GraphQLInputObjectType
-var GraphQLBoolean = require('graphql').GraphQLBoolean
-var GraphQLString = require('graphql').GraphQLString
+import { GraphQLObjectType, GraphQLInputObjectType, GraphQLBoolean, GraphQLString } from 'graphql'
 
-let dataShape = {
+const dataShape = {
   name: {
     type: GraphQLString,
     description: 'The name of the contact service (e.g. `Email address`)'
@@ -22,12 +19,14 @@ let dataShape = {
   }
 }
 
-exports.contactDetailsType = new GraphQLObjectType({
+const contactDetailsType = new GraphQLObjectType({
   name: 'contactDetails',
   fields: () => dataShape
 })
 
-exports.contactDetailsInputType = new GraphQLInputObjectType({
+const contactDetailsInputType = new GraphQLInputObjectType({
   name: 'contactDetailsInputType',
   fields: () => dataShape
 })
+
+export { contactDetailsType, contactDetailsInputType }

--- a/graphql/types/lang.js
+++ b/graphql/types/lang.js
@@ -1,13 +1,6 @@
-var GraphQLObjectType = require('graphql').GraphQLObjectType
-var GraphQLInputObjectType = require('graphql').GraphQLInputObjectType
-var GraphQLNonNull = require('graphql').GraphQLNonNull
-var GraphQLBoolean = require('graphql').GraphQLBoolean
-var GraphQLList = require('graphql').GraphQLList
-var GraphQLID = require('graphql').GraphQLID
-var GraphQLString = require('graphql').GraphQLString
-var GraphQLInt = require('graphql').GraphQLInt
+import { GraphQLObjectType, GraphQLInputObjectType, GraphQLNonNull, GraphQLBoolean, GraphQLList, GraphQLID, GraphQLString, GraphQLInt } from 'graphql'
 
-var childDataShape = {
+const childDataShape = {
   mobileMenuLabel: {
     type: GraphQLString,
     description: 'The alt text for the mobile menu icon'
@@ -19,19 +12,19 @@ var childDataShape = {
 }
 
 // Lang definitions Type
-var definitionsType = new GraphQLObjectType({
+const definitionsType = new GraphQLObjectType({
   name: 'definitions',
   fields: () => childDataShape
 })
 
-var definitionsInputType = new GraphQLInputObjectType({
+const definitionsInputType = new GraphQLInputObjectType({
   name: 'definitionsInputType',
   fields: () => childDataShape
 })
 
 // REFACTOR: Too many data shapes and not very DRY.
 
-var dataShape = {
+const dataShape = {
   language: {
     type: GraphQLString,
     description: 'The language being used (in `ISO 639-1` format (e.g. `en-gb`)'
@@ -42,7 +35,7 @@ var dataShape = {
   }
 }
 
-var dataShapeInput = {
+const dataShapeInput = {
   language: {
     type: GraphQLString,
     description: 'The language being used (in `ISO 639-1` format (e.g. `en-gb`)'
@@ -54,18 +47,18 @@ var dataShapeInput = {
 }
 
 // Lang Type
-var langType = new GraphQLObjectType({
+const langType = new GraphQLObjectType({
   name: 'lang',
   fields: () => dataShape
 })
 
 // Lang Input Type
-var langInputType = new GraphQLInputObjectType({
+const langInputType = new GraphQLInputObjectType({
   name: 'langInputType',
   fields: () => dataShapeInput
 })
 
-module.exports = {
+export {
   definitionsType,
   definitionsInputType,
   langType,

--- a/graphql/types/pages.js
+++ b/graphql/types/pages.js
@@ -1,13 +1,9 @@
-var GraphQLObjectType = require('graphql').GraphQLObjectType
-var GraphQLInputObjectType = require('graphql').GraphQLInputObjectType
-var GraphQLBoolean = require('graphql').GraphQLBoolean
-var GraphQLList = require('graphql').GraphQLList
-var GraphQLString = require('graphql').GraphQLString
+import { GraphQLObjectType, GraphQLInputObjectType, GraphQLBoolean, GraphQLList, GraphQLString } from 'graphql'
 
 // Import child types
-var ComponentType = require('./component')
+import ComponentType from './component'
 
-var dataShape = {
+const dataShape = {
   name: {
     type: GraphQLString,
     description: 'The name of the skill'
@@ -52,6 +48,7 @@ var dataShape = {
     type: GraphQLString,
     description: 'If the brand needs a special class, add it here'
   },
+
   //TODO: This requires some though as it's essentially passing an object into a page to render the rest. 
   // Maybe look into this some more when the frontend has been built
   components: {
@@ -61,13 +58,15 @@ var dataShape = {
 }
 
 // Pages Type
-exports.pagesType = new GraphQLObjectType({
+const pagesType = new GraphQLObjectType({
   name: 'pages',
   fields: () => dataShape
 })
 
 // Pages Input Type
-exports.pagesInputType = new GraphQLInputObjectType({
+const pagesInputType = new GraphQLInputObjectType({
   name: 'pagesInputType',
   fields: () => dataShape
 })
+
+export { pagesType, pagesInputType }

--- a/graphql/types/skills.js
+++ b/graphql/types/skills.js
@@ -1,13 +1,6 @@
-var GraphQLObjectType = require('graphql').GraphQLObjectType
-var GraphQLInputObjectType = require('graphql').GraphQLInputObjectType
-var GraphQLNonNull = require('graphql').GraphQLNonNull
-var GraphQLBoolean = require('graphql').GraphQLBoolean
-var GraphQLList = require('graphql').GraphQLList
-var GraphQLID = require('graphql').GraphQLID
-var GraphQLString = require('graphql').GraphQLString
-var GraphQLInt = require('graphql').GraphQLInt
+import { GraphQLObjectType, GraphQLInputObjectType, GraphQLNonNull, GraphQLBoolean, GraphQLString, GraphQLInt } from 'graphql'
 
-var dataShape = {
+const dataShape = {
   name: {
 		type: GraphQLString,
 		description: 'The name of the skill'
@@ -27,13 +20,15 @@ var dataShape = {
 }
 
 // Skills Type
-exports.skillsType = new GraphQLObjectType({
+const skillsType = new GraphQLObjectType({
   name: 'skills',
   fields: () => dataShape
 })
 
 // Skills Input Type
-exports.skillsInputType = new GraphQLInputObjectType({
+const skillsInputType = new GraphQLInputObjectType({
   name: 'skillsInputType',
   fields: () => dataShape
 })
+
+export { skillsType, skillsInputType }

--- a/graphql/types/social-networks.js
+++ b/graphql/types/social-networks.js
@@ -1,9 +1,6 @@
-var GraphQLObjectType = require('graphql').GraphQLObjectType
-var GraphQLInputObjectType = require('graphql').GraphQLInputObjectType
-var GraphQLBoolean = require('graphql').GraphQLBoolean
-var GraphQLString = require('graphql').GraphQLString
+import { GraphQLObjectType, GraphQLInputObjectType, GraphQLBoolean, GraphQLString } from 'graphql'
 
-let dataShape = {
+const dataShape = {
   name: {
     type: GraphQLString,
     description: 'The name of the social network'
@@ -30,12 +27,14 @@ let dataShape = {
   }
 }
 
-exports.socialNetworksType = new GraphQLObjectType({
+const socialNetworksType = new GraphQLObjectType({
   name: 'socialNetworks',
   fields: () => dataShape
 })
 
-exports.socialNetworksInputType = new GraphQLInputObjectType({
+const socialNetworksInputType = new GraphQLInputObjectType({
   name: 'socialNetworksInputType',
   fields: () => dataShape
 })
+
+export { socialNetworksType, socialNetworksInputType }

--- a/models/brands.js
+++ b/models/brands.js
@@ -1,11 +1,12 @@
-var mongoose = require('mongoose')
-var Schema = mongoose.Schema
+import mongoose from 'mongoose'
+
+const Schema = mongoose.Schema
 
 // Cache the collection name
-var c = 'Brands'
+const c = 'Brands'
 
 // Skills schema
-var BrandsSchema = new Schema({
+const BrandsSchema = new Schema({
   // Add children
   name: {
     type: String,
@@ -34,5 +35,4 @@ var BrandsSchema = new Schema({
 })
 
 // Export the model and specify the collection name to avoid pluralisation (hence the repeated 'c' variable)
-var Model = mongoose.model(c, BrandsSchema, c)
-module.exports = Model
+export default mongoose.model(c, BrandsSchema, c)

--- a/models/config.js
+++ b/models/config.js
@@ -1,11 +1,12 @@
-var mongoose = require('mongoose');
-var Schema = mongoose.Schema;
+import mongoose from 'mongoose'
+
+const Schema = mongoose.Schema
 
 // Cache the collection name
-var c = 'Config'
+const c = 'Config'
 
 // Config schema
-var ConfigSchema = new Schema({
+const ConfigSchema = new Schema({
   // Add children
   status: {
     type: String,
@@ -26,5 +27,4 @@ var ConfigSchema = new Schema({
 })
 
 // Export the model and specify the collection name to avoid pluralisation (hence the repeated 'c' variable)
-var Model = mongoose.model(c, ConfigSchema, c)
-module.exports = Model
+export default mongoose.model(c, ConfigSchema, c)

--- a/models/contact-details.js
+++ b/models/contact-details.js
@@ -1,10 +1,10 @@
-var mongoose = require('mongoose');
-var Schema = mongoose.Schema;
+import mongoose from 'mongoose'
+const Schema = mongoose.Schema;
 
 // Cache the collection name
-var c = 'ContactDetails'
+const c = 'ContactDetails'
 
-var ContactDetails = new Schema({
+const ContactDetails = new Schema({
   name: String,
   value: String,
   url: String,
@@ -12,5 +12,4 @@ var ContactDetails = new Schema({
 })
 
 // Export the model and specify the collection name to avoid pluralisation (hence the repeated 'c' variable)
-var Model = mongoose.model(c, ContactDetails, c)
-module.exports = Model
+export default mongoose.model(c, ContactDetails, c)

--- a/models/lang.js
+++ b/models/lang.js
@@ -1,17 +1,17 @@
-var mongoose = require('mongoose')
-var Schema = mongoose.Schema
+import mongoose from 'mongoose'
+const Schema = mongoose.Schema
 
 // Cache the collection name
-var c = 'Lang'
+const c = 'Lang'
 
-var DefinitionsSchema = new Schema({
+const DefinitionsSchema = new Schema({
   //add children
   'mobileMenuLabel' : String,
   'copyright' : String
 })
 
 // Language schema
-var LangSchema = new Schema({
+const LangSchema = new Schema({
   // Add children
   'language': {
     type: String,
@@ -21,5 +21,4 @@ var LangSchema = new Schema({
 })
 
 // Export the model and specify the collection name to avoid pluralisation (hence the repeated 'c' variable)
-var Model = mongoose.model(c, LangSchema, c)
-module.exports = Model
+export default mongoose.model(c, LangSchema, c)

--- a/models/pages.js
+++ b/models/pages.js
@@ -1,11 +1,11 @@
-var mongoose = require('mongoose')
-var Schema = mongoose.Schema
+import mongoose from 'mongoose'
+const Schema = mongoose.Schema
 
 // Cache the collection name
-var c = 'Pages'
+const c = 'Pages'
 
 // Skills schema
-var BrandsSchema = new Schema({
+const BrandsSchema = new Schema({
   // Add children
   name: {
     type: String,
@@ -53,5 +53,4 @@ var BrandsSchema = new Schema({
 })
 
 // Export the model and specify the collection name to avoid pluralisation (hence the repeated 'c' variable)
-var Model = mongoose.model(c, PagesSchema, c)
-module.exports = Model
+export default mongoose.model(c, PagesSchema, c)

--- a/models/skills.js
+++ b/models/skills.js
@@ -1,11 +1,11 @@
-var mongoose = require('mongoose');
-var Schema = mongoose.Schema;
+import mongoose from 'mongoose'
+const Schema = mongoose.Schema
 
 // Cache the collection name
-var c = 'Skills'
+const c = 'Skills'
 
 // Skills schema
-var SkillsSchema = new Schema({
+const SkillsSchema = new Schema({
   // Add children
   name: {
     type: String,
@@ -26,5 +26,4 @@ var SkillsSchema = new Schema({
 })
 
 // Export the model and specify the collection name to avoid pluralisation (hence the repeated 'c' variable)
-var Model = mongoose.model(c, SkillsSchema, c)
-module.exports = Model
+export default mongoose.model(c, SkillsSchema, c)

--- a/models/social-networks.js
+++ b/models/social-networks.js
@@ -1,10 +1,10 @@
-var mongoose = require('mongoose');
-var Schema = mongoose.Schema;
+import mongoose from 'mongoose'
+const Schema = mongoose.Schema;
 
 // Cache the collection name
-var c = 'SocialNetworks'
+const c = 'SocialNetworks'
 
-var SocialNetworks = new Schema({
+const SocialNetworks = new Schema({
   name: String,
   icon_class: String,
   username: String,
@@ -13,7 +13,5 @@ var SocialNetworks = new Schema({
   active: Boolean
 })
 
-
 // Export the model and specify the collection name to avoid pluralisation (hence the repeated 'c' variable)
-var Model = mongoose.model(c, SocialNetworks, c)
-module.exports = Model
+export default mongoose.model(c, SocialNetworks, c)

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
     "verbose": true
   },
   "scripts": {
+    "start" : "yarn serverstart & yarn appstart",
     "build": "webpack --mode production",
-    "serverstart": "node server.js",
+    "serverstart": "babel-node server.js",
     "appstart": "webpack-dev-server --open --mode development",
     "test" : "jest"
   },

--- a/server.js
+++ b/server.js
@@ -1,27 +1,25 @@
-// Import env file
-require('dotenv').config()
-
 // Import dependencies
-const express = require("express");
-const mongoose = require('./config/mongoose');
-const graphqlHTTP = require("express-graphql");
-const cors = require("cors");
-const db = mongoose();
-const app = express();
+import express from 'express'
+import mongoose from './config/mongoose'
+import graphqlHTTP from 'express-graphql'
+import cors from 'cors'
 
-app.use('*', cors());
+const db = mongoose()
+const app = express()
+
+app.use('*', cors())
 
 // import schemas
-const appSchema = require('./graphql/index').appSchema;
+import appSchema from'./graphql/index'
 
 // Set up schemas with Express endpoint
 app.use('/graphql', cors(), graphqlHTTP({
   schema: appSchema,
   rootValue: global,
   graphiql: true
-}));
+}))
 
 // Up and Running at Port 4000
 app.listen(process.env.PORT || 4000, () => {
-  console.log('A GraphQL API running at http://localhost:4000/graphql');
-});
+  console.log('A GraphQL API running at http://localhost:4000/graphql')
+})


### PR DESCRIPTION
- [x] refactored GraphQL to ES6
- [x] recactored Mongoose to ES6
- [x] updated package.json to set `serverstart` to use `babel-node` instead of vanilla node
- [x] updated package.json to override default `start` script with custom one which runs `serverstart` and `appstart` concurrently.